### PR TITLE
Windows Phone support

### DIFF
--- a/ionic-cache-src.js
+++ b/ionic-cache-src.js
@@ -216,6 +216,8 @@
                                     return $window.cordova.file.documentsDirectory;
                                 case 'Android':
                                     return $window.cordova.file.dataDirectory;
+                                case 'windows':		
+                                    return $window.cordova.file.dataDirectory;
                             }
                             return '';
                         };


### PR DESCRIPTION
Support for windows Phone, maybe you need to re-mapper cordova.file.dataDirectory as described in http://stackoverflow.com/questions/26910891/cordova-file-is-undefined-for-windows-wp8 according file plugin documentation https://github.com/apache/cordova-plugin-file on Windows File System Layout section.